### PR TITLE
can toggle x and y for percentage table

### DIFF
--- a/js/models/dashboard-items/percentage_table.js
+++ b/js/models/dashboard-items/percentage_table.js
@@ -66,7 +66,7 @@ ds.register_dashboard_item('percentage_table', {
     var table = $('#' + item.item_id + ' .ds-percentage-table-holder table')
     if (item.sortable) {
       table.DataTable({
-        order: [[ 2, "desc" ]],
+        order: [[ 1, "desc" ]],
         paging: false,
         searching: true,
         oLanguage: { sSearch: "" },

--- a/js/models/dashboard-items/percentage_table.js
+++ b/js/models/dashboard-items/percentage_table.js
@@ -10,6 +10,8 @@ ds.register_dashboard_item('percentage_table', {
     var self = limivorous.observable()
                          .property('format', {init: ',.3s'})
                          .property('title')
+                         .property('striped', {init: true})
+                         .property('sortable', {init: true})
                          .property('include_sums', {init: false})
                          .property('groups_as_rows', {init: false})
                          .property('transform', {init: 'sum'})
@@ -20,6 +22,8 @@ ds.register_dashboard_item('percentage_table', {
     if (data) {
       self.include_sums = data.include_sums
       self.groups_as_rows = data.groups_as_rows
+      self.striped = Boolean(data.striped)
+      self.sortable = Boolean(data.sortable)
       self.title = data.title
       self.format = data.format || self.format
       self.transform = data.transform || self.transform
@@ -32,6 +36,10 @@ ds.register_dashboard_item('percentage_table', {
         data.format = self.format
       if (self.groups_as_rows)
         data.groups_as_rows = self.groups_as_rows
+      if (self.striped)
+        data.striped = self.striped
+      if (self.sortable)
+        data.sortable = self.sortable
       if (self.title)
         data.title = self.title
       if (self.transform)
@@ -55,21 +63,27 @@ ds.register_dashboard_item('percentage_table', {
     var holder = $('#' + item.item_id + ' .ds-percentage-table-holder')
     holder.empty()
     holder.append(ds.templates.models.percentage_table_data({item:item, query:query}))
+    var table = $('#' + item.item_id + ' .ds-percentage-table-holder table')
+    if (item.sortable) {
+      table.DataTable({
+        order: [[ 2, "desc" ]],
+        paging: false,
+        searching: true,
+        oLanguage: { sSearch: "" },
+        info: true
+      })
+    }
   },
 
   template: ds.templates.models.percentage_table,
 
   interactive_properties: [
+    { id: 'striped', type: 'boolean' },
+    { id: 'sortable', type: 'boolean' },
+    { id: 'include_sums', type: 'boolean' },
+    { id: 'groups_as_rows', type: 'boolean' },
     'format',
     'title',
-    {
-      id: 'include_sums',
-      type: 'boolean'
-    },
-    {
-      id: 'groups_as_rows',
-      type: 'boolean'
-    },
     'transform'
   ].concat(ds.models.item.interactive_properties)
 })

--- a/js/models/dashboard-items/percentage_table.js
+++ b/js/models/dashboard-items/percentage_table.js
@@ -11,6 +11,7 @@ ds.register_dashboard_item('percentage_table', {
                          .property('format', {init: ',.3s'})
                          .property('title')
                          .property('include_sums', {init: false})
+                         .property('groups_as_rows', {init: false})
                          .property('transform', {init: 'sum'})
                          .extend(ds.models.item, {item_type: 'percentage_table'})
                          .build()
@@ -18,6 +19,7 @@ ds.register_dashboard_item('percentage_table', {
 
     if (data) {
       self.include_sums = data.include_sums
+      self.groups_as_rows = data.groups_as_rows
       self.title = data.title
       self.format = data.format || self.format
       self.transform = data.transform || self.transform
@@ -32,7 +34,7 @@ ds.register_dashboard_item('percentage_table', {
         data.title = self.title
       if (self.transform)
         data.transform = self.transform
-      data.include_sums = self.include_sums
+        data.include_sums = self.include_sums
       return data
     }
 
@@ -60,6 +62,10 @@ ds.register_dashboard_item('percentage_table', {
     'title',
     {
       id: 'include_sums',
+      type: 'boolean'
+    },
+    {
+      id: 'groups_as_rows',
       type: 'boolean'
     },
     'transform'

--- a/js/models/dashboard-items/percentage_table.js
+++ b/js/models/dashboard-items/percentage_table.js
@@ -66,7 +66,7 @@ ds.register_dashboard_item('percentage_table', {
     var table = $('#' + item.item_id + ' .ds-percentage-table-holder table')
     if (item.sortable) {
       table.DataTable({
-        order: [[ 1, "desc" ]],
+        order: [[ 2, "desc" ]],
         paging: false,
         searching: true,
         oLanguage: { sSearch: "" },

--- a/js/models/dashboard-items/percentage_table.js
+++ b/js/models/dashboard-items/percentage_table.js
@@ -30,6 +30,8 @@ ds.register_dashboard_item('percentage_table', {
       var data = ds.models.item.json(self)
       if (self.format)
         data.format = self.format
+      if (self.groups_as_rows)
+        data.groups_as_rows = self.groups_as_rows
       if (self.title)
         data.title = self.title
       if (self.transform)

--- a/templates/models/percentage_table_data.hbs
+++ b/templates/models/percentage_table_data.hbs
@@ -1,33 +1,69 @@
 <table class="table table-condensed ds-percentage-table">
 
-  <thead>
-    <tr>
-      <th></th>
-      <th>%</th>
+  {{#if item.groups_as_rows}}
+    <thead>
+      <tr>
+        <th></th>
+        <th>%</th>
+        {{#if item.include_sums}}
+          <th>{{item.transform}}</th>
+        {{/if}}
+      </tr>
+    </thead>
+
+    <tbody>
+      {{#each query.data}}
+        <tr>
+          <th>{{target}}</th>
+          <td>{{format ",.2%" summation.percent}}</td>
+          {{#if ../item.include_sums}}
+            <td>{{format ../item.format summation.percent_value}}</td>
+        {{/if}}
+        </tr>
+      {{/each}}
+
       {{#if item.include_sums}}
-        <th>{{item.transform}}</th>
+        <tr>
+          <th>Total</th>
+          <td></td>
+          <td>{{format item.format query.summation.percent_value}}</td>
+        </tr>
       {{/if}}
-    </tr>
-  </thead>
-
-  <tbody>
-    {{#each query.data}}
+    </tbody>
+  {{else}}
+    <thead>
       <tr>
-        <th>{{target}}</th>
-        <td>{{format ",.2%" summation.percent}}</td>
-        {{#if ../item.include_sums}}
-          <td>{{format ../item.format summation.percent_value}}</td>
+        {{#if item.include_sums}}
+          <th></th>
+          <th>Total</th>
+        {{/if}}
+        {{#each query.data}}
+          <th>{{target}}</th>
+        {{/each}}
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        {{#if item.include_sums}}
+          <th>%</th>
+          <th></th>
+        {{/if}}
+        {{#each query.data}}
+          <td>{{format ",.2%" summation.percent}}</td>
+        {{/each}}
+      </tr>
+
+      {{#if item.include_sums}}
+        <tr>
+          <th>{{item.transform}}</th>
+          <td>{{format item.format query.summation.percent_value}}</td>
+          {{#each query.data}}
+            <td>{{format ../../item.format summation.percent_value}}</td>
+          {{/each}}
+        </tr>
       {{/if}}
-      </tr>
-    {{/each}}
-
-    {{#if item.include_sums}}
-      <tr>
-        <th>Total</th>
-        <td></td>
-        <td>{{format item.format query.summation.percent_value}}</td>
-      </tr>
-    {{/if}}
-  </tbody>
+    </tbody>
+  {{/if}}
 
 </table>

--- a/templates/models/percentage_table_data.hbs
+++ b/templates/models/percentage_table_data.hbs
@@ -18,16 +18,16 @@
           <th>{{target}}</th>
           <td>{{format ",.2%" summation.percent}}</td>
           {{#if ../item.include_sums}}
-            <td>{{format ../item.format summation.percent_value}}</td>
+            <td>{{format ",.0f" summation.percent_value}}</td>
         {{/if}}
         </tr>
       {{/each}}
 
       {{#if item.include_sums}}
         <tr>
-          <th>Total</th>
+          <th>TOTAL</th>
           <td></td>
-          <td>{{format item.format query.summation.percent_value}}</td>
+          <td>{{format ",.0f" query.summation.percent_value}}</td>
         </tr>
       {{/if}}
     </tbody>

--- a/templates/models/percentage_table_data.hbs
+++ b/templates/models/percentage_table_data.hbs
@@ -1,4 +1,5 @@
-<table class="table table-condensed ds-percentage-table">
+<table class="table table-condensed ds-percentage-table {{css_class item}}
+                {{#if item.striped}}table-striped{{/if}}">
 
   {{#if item.groups_as_rows}}
     <thead>

--- a/templates/models/percentage_table_data.hbs
+++ b/templates/models/percentage_table_data.hbs
@@ -2,37 +2,32 @@
 
   <thead>
     <tr>
+      <th></th>
+      <th>%</th>
       {{#if item.include_sums}}
-        <th></th>
-        <th>Total</th>
+        <th>{{item.transform}}</th>
       {{/if}}
-      {{#each query.data}}
-        <th>{{target}}</th>
-      {{/each}}
     </tr>
   </thead>
 
   <tbody>
-    <tr>
-      {{#if item.include_sums}}
-        <th>%</th>
-        <th></th>
-      {{/if}}
-      {{#each query.data}}
+    {{#each query.data}}
+      <tr>
+        <th>{{target}}</th>
         <td>{{format ",.2%" summation.percent}}</td>
-      {{/each}}
-    </tr>
+        {{#if ../item.include_sums}}
+          <td>{{format ../item.format summation.percent_value}}</td>
+      {{/if}}
+      </tr>
+    {{/each}}
 
     {{#if item.include_sums}}
       <tr>
-        <th>{{item.transform}}</th>
+        <th>Total</th>
+        <td></td>
         <td>{{format item.format query.summation.percent_value}}</td>
-        {{#each query.data}}
-          <td>{{format ../../item.format summation.percent_value}}</td>
-        {{/each}}
       </tr>
     {{/if}}
-
   </tbody>
 
 </table>


### PR DESCRIPTION
I wasn't quite sure how to name this.  My usage was with groups of series, so I thought groups_as_rows, but maybe you can think of a better name.  invert_x_y came to mind, but it seems like it could potentially be inconsistent with the other tables, since those already seem to list the groups down the y.

Also, I wasn't sure if this made sense to fiddle with in the toJSON function in the model, so I chose not to. See:
js/models/dashboard-items/percentage_table.js