### PR TITLE
Cleaner handling of URI paths

### DIFF
--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -286,9 +286,9 @@ ds.manager =
         var url = URI(window.location)
         var path = url.path()
         if (target.item_type != 'dashboard_definition') {
-          path = path + '/' + target.item_id
+          path.segment(target.item_id.toString())
         }
-        path = path + '/transform/' + transform.name
+        path.segment('transform').segment(transform.name)
         window.history.pushState({ url:self.current.url,
                                    element:self.current.element,
                                    transform:transform.toJSON(),

--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -47,12 +47,11 @@ ds.models.data.Query = function(data) {
 
   self.url = function(opt) {
     var options = ds.extend(self.local_options, opt, self.options)
-    var url = URI(options.base_url || ds.config.GRAPHITE_URL);
-    var path = url.path();
-    url = url.path(path + '/render')
-              .setQuery('format', options.format || 'png')
-              .setQuery('from', options.from || ds.config.DEFAULT_FROM_TIME || self.DEFAULT_FROM_TIME)
-              .setQuery('tz', ds.config.DISPLAY_TIMEZONE)
+    var url = new URI(options.base_url || ds.config.GRAPHITE_URL);
+    url = url.segment('render')
+             .setQuery('format', options.format || 'png')
+             .setQuery('from', options.from || ds.config.DEFAULT_FROM_TIME || self.DEFAULT_FROM_TIME)
+             .setQuery('tz', ds.config.DISPLAY_TIMEZONE)
     if (options.until) {
       url.setQuery('until', options.until)
     }


### PR DESCRIPTION
Use
[`URI.segment()`](http://medialize.github.io/URI.js/docs.html#accessors-
segment) to append URL path segments, rather than string concatenation,
avoid occasional double slashes.