### PR TITLE
Issue #284: Add preference for property sheet autoclose time

### DIFF
--- a/js/app/handlers/edit-mode.js
+++ b/js/app/handlers/edit-mode.js
@@ -191,8 +191,6 @@
     return $('#' + item.item_id + '-details').is(':visible')
   }
 
-  var PROPERTY_SHEET_TIMEOUT = 3000
-
   /**
    * Event handlers to show & hide the action bar & property sheet for
    * dashboard items.
@@ -218,10 +216,13 @@
   $(document).on('mouseleave', '.ds-edit-bar', function(event) {
     var $elt = $(this)
     var id   = $elt.attr('data-ds-item-id')
-    var timeout_id = window.setTimeout(function() {
-                       ds.edit.hide_details(id)
-                     }, PROPERTY_SHEET_TIMEOUT)
-    $elt.attr('data-ds-timeout-id', timeout_id)
+    var timeout = ds.config.PROPSHEET_AUTOCLOSE_SECONDS
+    if (timeout && timeout > 0) {
+      var timeout_id = window.setTimeout(function() {
+                         ds.edit.hide_details(id)
+                       }, timeout * 1000)
+      $elt.attr('data-ds-timeout-id', timeout_id)
+    }
   })
 
   /**

--- a/tessera/templates/preferences.html
+++ b/tessera/templates/preferences.html
@@ -109,6 +109,8 @@
             </div>
           </div>
 
+          <hr/>
+
           <!-- Chart Style -->
           <div class="form-group">
             <label class="col-md-4 control-label" for="chartRadios">Default Chart Style</label>
@@ -207,6 +209,34 @@
 
             </div>
           </div>
+
+          <hr/>
+
+          <!-- Property Sheet Auto-Close Timeout -->
+          <div class="form-group">
+            <div class="col-md-4"
+                 style="text-align:right">
+              <label class="control-label" for="numberPropertySheetAutoClose">Property Sheet Auto-Close Time</label><br/>
+              <small>In seconds. Set value to 0 to disable autoclose.</small>
+            </div>
+            <div class="col-md-6">
+              <input type="number" step="1" id="numberPropertySheetAutoClose" name="numberPropertySheetAutoClose"
+                     class="form-control"
+                     value="{{ctx.get_int('propsheet_autoclose_seconds', config.get('DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS',3))}}"
+                     onchange="dsSetPref('propsheet_autoclose_seconds', this.value)">
+              </input>
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-default"
+                      id="ds-reset-propertysheet-timeout-button"
+                      data-toggle="tooltip"
+                      title="Reset to Default">
+                <i class="fa fa-angle-double-down"></i>
+              </button>
+            </div>
+
+          </div>
+
         </fieldset>
       </form>
 
@@ -263,6 +293,13 @@
    dsSetPref('graphite_url', e.value)
    return false
  })
+
+ $(document).on('click', '#ds-reset-propertysheet-timeout-button', function(e) {
+   $('#numberPropertySheetAutoClose')[0].value = {{config.get('DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS',3)}}
+   dsSetPref('propsheet_autoclose_seconds', e.value)
+   return false
+ })
+
 
 </script>
 

--- a/tessera/templates/snippets/site-header.html
+++ b/tessera/templates/snippets/site-header.html
@@ -15,6 +15,7 @@
   ds.config.GRAPHITE_URL = "{{ctx.get_str('graphite_url', config.get('GRAPHITE_URL'))}}"
   ds.config.GRAPHITE_AUTH = "{{ctx.get_str('graphite_auth', config.get('GRAPHITE_AUTH'))}}"
   ds.config.DISPLAY_TIMEZONE = "{{ctx.get_str('timezone', config.get('DISPLAY_TIMEZONE','UTC'))}}"
+  ds.config.PROPSHEET_AUTOCLOSE_SECONDS = {{ctx.get_int('propsheet_autoclose_seconds', config.get('DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS',3))}}
   ds.config.DEFAULT_FROM_TIME = "{{config.get('DEFAULT_FROM_TIME')}}"
   {% if config.get('APPLICATION_ROOT') %}
   ds.config.APPLICATION_ROOT = "{{config.get('APPLICATION_ROOT')}}"

--- a/tessera/views.py
+++ b/tessera/views.py
@@ -72,7 +72,8 @@ defaults.
         'refresh' : _get_param('refresh', app.config['DEFAULT_REFRESH_INTERVAL'], store_in_session=store_in_session),
         'timezone' : _get_param('timezone', app.config['DISPLAY_TIMEZONE'], store_in_session=store_in_session),
         'graphite_url' : _get_param('graphite_url', app.config['GRAPHITE_URL'], store_in_session=store_in_session),
-        'graphite_auth' : _get_param('graphite_auth', app.config['GRAPHITE_AUTH'], store_in_session=store_in_session)
+        'graphite_auth' : _get_param('graphite_auth', app.config['GRAPHITE_AUTH'], store_in_session=store_in_session),
+        'propsheet_autoclose_seconds' : _get_param('propsheet_autoclose_seconds', app.config['DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS'], store_in_session=store_in_session)
     }
 
 def _set_preferences(prefs):


### PR DESCRIPTION
Setting the autoclose time to 0 disables auto-closing of property sheets. Implements #284 