### PR TITLE
Issue 387: Add ability to display only non-zero series in discrete charts

### DIFF
--- a/js/charts/flot.js
+++ b/js/charts/flot.js
@@ -203,6 +203,8 @@
       var data = query.chart_data('flot')
       for (var i = 0; i < data.length; i++) {
         var series = data[i]
+        if (item.hide_zero_series && series.summation.sum === 0)
+          continue
         var label = series.label
         var color = options.colors[i % options.colors.length]
 
@@ -323,12 +325,14 @@
 
       var transform = item.transform || 'sum'
       var data = query.chart_data('flot').map(function(series) {
+                   if (item.hide_zero_series && series.summation.sum === 0)
+                     return undefined
                    return {
                      label: series.label,
                      summation: series.summation,
                      data: [ series.label, series.summation[transform] ]
                    }
-                 })
+                 }).filter(function(item) { return item })
 
       render(e, item, query, options, data)
 
@@ -417,6 +421,8 @@
       var transform = item.transform || 'sum'
       var index = 0
       var data = query.chart_data('flot').map(function(series) {
+                   if (item.hide_zero_series && series.summation.sum === 0)
+                     return undefined
                    return {
                      label: series.label,
                      data: [
@@ -426,7 +432,7 @@
                      ],
                      color: options.colors[options.colors % index++]
                    }
-                 })
+                 }).filter(function(item) { return item })
       index = 0
       var ticks = data.map(function(series) {
                               return [index++, series.label]

--- a/js/models/dashboard-items/discrete_bar_chart.js
+++ b/js/models/dashboard-items/discrete_bar_chart.js
@@ -15,6 +15,7 @@ ds.register_dashboard_item('discrete_bar_chart', {
                          .property('format', {init: ',.3s'})
                          .property('show_grid', {init: true})
                          .property('show_numbers', {init: true})
+                         .property('hide_zero_series', {init: false})
                          .build()
 
     if (data) {
@@ -22,10 +23,15 @@ ds.register_dashboard_item('discrete_bar_chart', {
       self.transform = data.transform || self.transform
       self.orientation = data.orientation || self.orientation
       self.format = data.format || self.format
-      if (typeof(data.show_grid) !== 'undefined')
-        self.show_grid = data.show_grid
-      if (typeof(data.show_numbers) !== 'undefined')
-        self.show_numbers = data.show_numbers
+      if (typeof(data.show_grid) !== 'undefined') {
+        self.show_grid = Boolean(data.show_grid)
+      }
+      if (typeof(data.show_numbers) !== 'undefined') {
+        self.show_numbers = Boolean(data.show_numbers)
+      }
+      if (typeof(data.hide_zero_series !== 'undefined')) {
+        self.hide_zero_series = Boolean(data.hide_zero_series)
+      }
     }
 
     ds.models.chart.init(self, data)
@@ -37,7 +43,8 @@ ds.register_dashboard_item('discrete_bar_chart', {
         transform: self.transform,
         format: self.format,
         show_grid: self.show_grid,
-        show_numbers: self.show_numbers
+        show_numbers: self.show_numbers,
+        hide_zero_series: self.hide_zero_series
       }))
     }
 
@@ -55,6 +62,7 @@ ds.register_dashboard_item('discrete_bar_chart', {
     'format',
     { id: 'show_grid', type: 'boolean' },
     { id: 'show_numbers', type: 'boolean' },
+    { id: 'hide_zero_series', type: 'boolean' },
     {
       id: 'orientation',
       type: 'select',

--- a/js/models/dashboard-items/donut_chart.js
+++ b/js/models/dashboard-items/donut_chart.js
@@ -12,6 +12,7 @@ ds.register_dashboard_item('donut_chart', {
                          .extend(ds.models.chart)
                          .property('labels', {init: false})
                          .property('is_pie', {init: false})
+                         .property('hide_zero_series', {init: false})
                          .build()
     Object.defineProperty(self, 'requires_data', {value: true})
 
@@ -22,6 +23,9 @@ ds.register_dashboard_item('donut_chart', {
       if (typeof(data.is_pie) !== 'undefined') {
         self.is_pie = Boolean(data.is_pie)
       }
+      if (typeof(data.hide_zero_series !== 'undefined')) {
+        self.hide_zero_series = Boolean(data.hide_zero_series)
+      }
     }
 
     ds.models.chart.init(self, data)
@@ -30,7 +34,8 @@ ds.register_dashboard_item('donut_chart', {
     self.toJSON = function() {
       return ds.models.chart.json(self, ds.models.item.json(self, {
         labels: self.labels,
-        is_pie: self.is_pie
+        is_pie: self.is_pie,
+        hide_zero_series: self.hide_zero_series
       }))
     }
 
@@ -45,7 +50,8 @@ ds.register_dashboard_item('donut_chart', {
 
   interactive_properties: [
     { id: 'labels', type: 'boolean' },
-    { id: 'is_pie', type: 'boolean' }
+    { id: 'is_pie', type: 'boolean' },
+    { id: 'hide_zero_series', type: 'boolean' },
   ].concat(ds.models.chart.interactive_properties,
            ds.models.item.interactive_properties)
 


### PR DESCRIPTION
Implements #387. Filter out data series which sum to zero in donut & discrete bar charts. This makes them much more useful for queries which return many data series of which only a small number are likely to be non-zero.