### PR TITLE
Issue 329: Fix broken reload of TimeSpans transform

### DIFF
--- a/js/models/transform/TimeSpans.js
+++ b/js/models/transform/TimeSpans.js
@@ -36,6 +36,12 @@ ds.transforms.register({
                                     : 'Time Spans' }))
                     .add(make('separator'))
 
+    section.add(make('cell')
+                  .set_span(colspan)
+                  .set_style('well')
+                  .add(item.set_title('Original')))
+           .add(make('separator'))
+
     for (var i = 0; i < spans.length; i++) {
       var span = spans[i]
       var modified_query = ds.models.data.Query(query.toJSON())


### PR DESCRIPTION
Include original item in the transform. This is a workaround for #329 to ensure reloading works - the original item’s query disappears otherwise. Filing a separate issue to refactor transform logic in general to clean it up. 