### PR TITLE
Issue 410: loading too much data

### DIFF
--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -95,21 +95,6 @@ ds.manager =
     }
 
     /**
-     * Recurse through the presentation tree, giving each dashboard
-     * item an element ID, and checking to see if we have any
-     * components that require the raw data queries to be made.
-     */
-    self._prep_items = function(dashboard, holder, interactive) {
-      dashboard.visit(function(item) {
-        if (!item.item_type)
-          return
-        if (item.requires_data) {
-          holder.raw_data_required = true
-        }
-      })
-    }
-
-    /**
      * Set up us the API call.
      */
     self._prep_url = function(base_url, options) {
@@ -162,20 +147,13 @@ ds.manager =
           ds.charts.provider = ds.charts.registry.get(data.preferences.renderer)
         }
 
-          ds.event.fire(self, ds.app.Event.DASHBOARD_LOADED, dashboard)
+        ds.event.fire(self, ds.app.Event.DASHBOARD_LOADED, dashboard)
 
-          dashboard.render_templates(context.variables)
+        dashboard.render_templates(context.variables)
 
-          var interactive = ds.charts.provider.is_interactive
-          if (context.interactive != undefined) {
-            interactive = context.interactive
-          }
-          holder.raw_data_required = interactive
-          ds.charts.interactive = interactive
-
-          // Build a map from the presentation elements to their
-          // model objects.
-          self._prep_items(dashboard, holder, interactive)
+        ds.charts.interactive = (context.interactive != undefined)
+                              ? context.interactive
+                              : ds.charts.provider.is_interactive
 
           // Render the dashboard
           $(element).html(dashboard.definition.render())
@@ -193,7 +171,7 @@ ds.manager =
             dashboard.definition.load_all({
               from: context.from,
               until: context.until
-            }, !holder.raw_data_required)
+            })
           }
 
           ds.event.fire(self, ds.app.Event.DASHBOARD_RENDERED, dashboard)

--- a/js/dashboard/models/dashboard-items/donut_chart.js
+++ b/js/dashboard/models/dashboard-items/donut_chart.js
@@ -14,7 +14,6 @@ ds.register_dashboard_item('donut_chart', {
                          .property('is_pie', {init: false})
                          .property('hide_zero_series', {init: false})
                          .build()
-    Object.defineProperty(self, 'requires_data', {value: true})
 
     if (data) {
       if (typeof(data.labels) !== 'undefined') {

--- a/js/dashboard/models/data/Query.js
+++ b/js/dashboard/models/data/Query.js
@@ -33,6 +33,7 @@ ds.models.data.Query = function(data) {
   self.DEFAULT_FROM_TIME = '-3h'
   self.perf = ds.perf('ds.models.data.Query', self.name)
   self.cache = {}
+  self.load_count = 0
 
   Object.defineProperty(self, 'is_query', {value: true})
 
@@ -142,7 +143,6 @@ ds.models.data.Query = function(data) {
     return output;
   }
 
-
   /**
    * Asynchronously load the data for this query from the graphite
    * server, notifying any listening consumers when the data is
@@ -179,6 +179,7 @@ ds.models.data.Query = function(data) {
       options.format = 'json'
       var url = self.url(options)
       ds.event.fire(self, 'ds-data-loading')
+      self.load_count += 1
       return $.ajax({
         dataType: 'jsonp',
         url: url,


### PR DESCRIPTION
Fixes #410 

We were loading queries far too much when raw data is required. This change splits up the query load process.

Instead of just calling load() on all queries, `dashboard_definition.load_all()` now walks the tree to collect the queries that are actually referenced by a dashboard item, and splits them into two groups - one to load, and one to just fire (firing the loaded event is still necessary, as the `data_handler` is where chart items load their PNG from graphite when using the graphite renderer).