### PR TITLE
Quick bug fix: Default to 0 in RenderContext.get_int(), not None

### DIFF
--- a/tessera/_version.py
+++ b/tessera/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 6, 0)
+__version_info__ = (0, 6, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tessera/views.py
+++ b/tessera/views.py
@@ -372,7 +372,7 @@ class RenderContext:
     def get(self, key, default=None, store_in_session=False):
         return _get_param(key, default=default, store_in_session=store_in_session)
 
-    def get_int(self, key, default=None, store_in_session=False):
+    def get_int(self, key, default=0, store_in_session=False):
         return int(self.get(key, default=default, store_in_session=store_in_session))
 
     def get_str(self, key, default=None, store_in_session=False):

--- a/tessera/views.py
+++ b/tessera/views.py
@@ -373,7 +373,7 @@ class RenderContext:
         return _get_param(key, default=default, store_in_session=store_in_session)
 
     def get_int(self, key, default=0, store_in_session=False):
-        return int(self.get(key, default=default, store_in_session=store_in_session))
+        return int(self.get(key, default=default, store_in_session=store_in_session) or 0)
 
     def get_str(self, key, default=None, store_in_session=False):
         return str(self.get(key, default=default, store_in_session=store_in_session))


### PR DESCRIPTION
In some deployments, we're choking on (a lack of) one of the new config parameters; `RenderContext.get_int()` shouldn't allow `None` to be passed to `int()`