### PR TITLE
fix view source button

### DIFF
--- a/js/app/handlers/dashboard-toolbar.js
+++ b/js/app/handlers/dashboard-toolbar.js
@@ -123,7 +123,7 @@ $(document).ready(function() {
   $(document).on('click', '#ds-view-dashboard-source-button', function(e) {
     var dashboard = ds.manager.current.dashboard
     $.get(dashboard.href + '?definition=true', function(data) {
-      var contents = '<div class="container">' + ds.templates.edit.item_source({item:data.dashboards[0]}) + '</div>'
+      var contents = '<div class="container">' + ds.templates.edit.item_source({item:data}) + '</div>'
       $(ds.manager.current.element).html(contents)
     })
   })


### PR DESCRIPTION
When fetching the dashboard definition there's no 'dashboard' outer object,
pass the whole dashboard as it is.