### PR TITLE
Fix min/max calculation for empty series

### DIFF
--- a/js/dashboard/models/data/Summation.js
+++ b/js/dashboard/models/data/Summation.js
@@ -81,10 +81,6 @@ ds.models.data.Summation = function(initial_data) {
       }
       index++
     })
-    if (self.sum === 0) {
-      self.min = 0
-      self.max = 0
-    }
     self.mean = self.sum / self.count
   } else if (typeof(initial_data) === 'object') {
     self.sum   = if_defined(initial_data.sum,  self.sum)
@@ -98,6 +94,11 @@ ds.models.data.Summation = function(initial_data) {
     self.mean  = if_defined(initial_data.mean, self.mean)
     self.mean  = if_defined(initial_data.median, self.median)
     self.count = if_defined(initial_data.count, self.count)
+  }
+
+  if (self.sum === 0) {
+    self.min = 0
+    self.max = 0
   }
 
   /**


### PR DESCRIPTION
The defaulting of min/max to 0 wasn't being applied in all
circumstances; if there were no datapoints at all, they would remain at
`Number.MAX_VALUE` and `Number.MIN_VALUE` respectively.

I'm not convinced this fully resolves the issues here (e.g. shouldn't it
be perfectly possible for sum to be 0 _and_ for min/max to have real
values, if you have a dataset of mixed negative/positive values or just
all zeros?), but it fixes my issue at least!