### PR TITLE
Implement connected line mode for Flot charts

### DIFF
--- a/js/charts/flot.js
+++ b/js/charts/flot.js
@@ -266,6 +266,11 @@
       result.data = series.datapoints.map(function(point) {
                       return [point[1] * 1000, point[0]]
                     })
+      if (ds.config.CONNECTED_LINES) {
+        result.data = result.data.filter(function(point) {
+          return point[1] != null
+        })
+      }
       return result
     }
 

--- a/js/charts/graphite.js
+++ b/js/charts/graphite.js
@@ -45,7 +45,7 @@ ds.charts.graphite =
             .setQuery('colorList', ds.charts.util.get_palette(options.palette).join())
             .setQuery('title', options.showTitle ? item.title : '')
 
-      if (ds.config.GRAPHITE_CONNECTED_LINES) {
+      if (ds.config.CONNECTED_LINES) {
         png_url.setQuery('lineMode', 'connected')
       }
 

--- a/tessera/config.py
+++ b/tessera/config.py
@@ -65,12 +65,12 @@ GRAPHITE_URL               = 'http://localhost:8080'
 GRAPHITE_AUTH              = ''
 
 #
-# Whether or not to render graphite PNGs with
-# lineMode=connected. Connected line mode can be useful when your data
-# is sparse, but it can also mask scalability problems with your
-# Graphite installation.
+# Whether to render charts with lines between each consecutive non-null
+# point.
+# Connected line mode can be useful when your data is sparse, but it
+# can also mask scalability problems with your Graphite installation.
 #
-GRAPHITE_CONNECTED_LINES   = 0
+CONNECTED_LINES            = 0
 
 #
 # The default renderer for charts. Valid values are 'graphite', for

--- a/tessera/templates/snippets/site-header.html
+++ b/tessera/templates/snippets/site-header.html
@@ -14,7 +14,7 @@
   ds.config = ds.config || {}
   ds.config.GRAPHITE_URL = "{{ctx.get_str('graphite_url', config.get('GRAPHITE_URL'))}}"
   ds.config.GRAPHITE_AUTH = "{{ctx.get_str('graphite_auth', config.get('GRAPHITE_AUTH'))}}"
-  ds.config.GRAPHITE_CONNECTED_LINES = {{ctx.get_int('graphite_connected_lines', config.get('GRAPHITE_CONNECTED_LINES'))}}
+  ds.config.CONNECTED_LINES = {{ctx.get_int('connected_lines', config.get('CONNECTED_LINES'))}}
   ds.config.DISPLAY_TIMEZONE = "{{ctx.get_str('timezone', config.get('DISPLAY_TIMEZONE','UTC'))}}"
   ds.config.PROPSHEET_AUTOCLOSE_SECONDS = {{ctx.get_int('propsheet_autoclose_seconds', config.get('DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS',3))}}
   ds.config.DEFAULT_FROM_TIME = "{{config.get('DEFAULT_FROM_TIME')}}"

--- a/tessera/views.py
+++ b/tessera/views.py
@@ -77,7 +77,7 @@ defaults.
         'timezone' : _get_param('timezone', app.config['DISPLAY_TIMEZONE'], store_in_session=store_in_session),
         'graphite_url' : _get_param('graphite_url', app.config['GRAPHITE_URL'], store_in_session=store_in_session),
         'graphite_auth' : _get_param('graphite_auth', app.config['GRAPHITE_AUTH'], store_in_session=store_in_session),
-        'graphite_connected_lines' : _get_param('graphite_connected_lines', app.config['GRAPHITE_CONNECTED_LINES'], store_in_session=store_in_session),
+        'connected_lines' : _get_param('connected_lines', app.config['CONNECTED_LINES'], store_in_session=store_in_session),
         'propsheet_autoclose_seconds' : _get_param('propsheet_autoclose_seconds', app.config['DEFAULT_PROPSHEET_AUTOCLOSE_SECONDS'], store_in_session=store_in_session)
     }
 


### PR DESCRIPTION
Also renamed the GRAPHITE_CONNECTED_LINES config to just
CONNECTED_LINES, because if you want connected lines you
probably want them in all renderers.

Resolves #404.