### PR TITLE
Add virtualenv local/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lib/
 include/
 man/
 dist/
+local/
 .Python
 bower_components/
 node_modules/


### PR DESCRIPTION
Virtualenv on some common platforms (e.g. Ubuntu + Python 2.7) will
create a local/ directory in the Virtualenv base directory; this adds
that directory to the .gitignore (the other directories that Virtualenv
creates are already ignored).