### PR TITLE
Add per-chart renderer overrides

### DIFF
--- a/demo/release-notes-what-s-new-in-0-7.json
+++ b/demo/release-notes-what-s-new-in-0-7.json
@@ -55,7 +55,8 @@
                 "items": [
                   {
                     "item_id": "d29", 
-                    "item_type": "markdown"
+                    "item_type": "markdown", 
+                    "text": "The big news is that the client-side JavaScript code has been\nre-written in Microsoft's\n[TypeScript](http://www.typescriptlang.org/). TypeScript is a\nsuperset of the ECMAScript 6 specification with optional type\nannotations, which compiles down to JavaScript. "
                   }
                 ]
               }
@@ -169,6 +170,66 @@
                 ]
               }
             ]
+          }, 
+          {
+            "item_id": "d35", 
+            "item_type": "separator"
+          }, 
+          {
+            "item_id": "d30", 
+            "item_type": "row", 
+            "items": [
+              {
+                "item_id": "d31", 
+                "item_type": "cell", 
+                "offset": "1", 
+                "span": 3, 
+                "items": [
+                  {
+                    "item_id": "d32", 
+                    "item_type": "markdown", 
+                    "text": "### Override Chart Renderer\n\nThe chart renderer can now be set on a per-chart basis,\noverriding the default.\n\nNow if there\u2019s something you need to do with a graphite query\nthat flot charts don\u2019t support, you can selectively use\ngraphite\u2019s PNG renderer.\n"
+                  }
+                ]
+              }, 
+              {
+                "item_id": "d33", 
+                "item_type": "cell", 
+                "span": "4", 
+                "items": [
+                  {
+                    "title": "Flot Renderer", 
+                    "stack_mode": "stack", 
+                    "item_type": "stacked_area_chart", 
+                    "hide_zero_series": false, 
+                    "renderer": "flot", 
+                    "item_id": "d39", 
+                    "query": "group", 
+                    "legend": "simple", 
+                    "interactive": true
+                  }
+                ]
+              }, 
+              {
+                "item_id": "d40", 
+                "item_type": "cell", 
+                "span": "4", 
+                "items": [
+                  {
+                    "title": "Graphite Renderer", 
+                    "stack_mode": "stack", 
+                    "height": "3", 
+                    "item_type": "stacked_area_chart", 
+                    "hide_zero_series": false, 
+                    "renderer": "graphite", 
+                    "item_id": "d41", 
+                    "query": "group", 
+                    "legend": "simple", 
+                    "interactive": true
+                  }
+                ]
+              }
+            ]
           }
         ], 
         "title": "New Dashboard Items", 
@@ -178,12 +239,18 @@
       }
     ], 
     "item_type": "dashboard_definition", 
-    "href": "/api/dashboard/24/definition", 
+    "href": "/api/dashboard/11/definition", 
     "queries": {
       "duration": {
         "name": "duration", 
         "targets": [
           "absolute(randomWalkFunction(\"query0\"))"
+        ]
+      }, 
+      "group": {
+        "name": "group", 
+        "targets": [
+          "group(absolute(randomWalkFunction(\"series1\")), absolute(randomWalkFunction(\"series2\")), absolute(randomWalkFunction(\"series3\")))"
         ]
       }
     }, 
@@ -192,25 +259,25 @@
       "from": "-3h"
     }
   }, 
-  "view_href": "/dashboards/24/what-s-new-in-0-7", 
+  "view_href": "/dashboards/11/what-s-new-in-0-7", 
   "description": null, 
   "tags": [
     {
       "count": 9, 
       "bgcolor": "green", 
-      "id": 1, 
+      "id": 6, 
       "name": "featured"
     }, 
     {
       "count": 2, 
-      "id": 3, 
+      "id": 14, 
       "name": "release-notes"
     }
   ], 
   "title": "What's new in 0.7?", 
   "summary": "", 
-  "definition_href": "/api/dashboard/24/definition", 
-  "href": "/api/dashboard/24", 
-  "id": 24, 
+  "definition_href": "/api/dashboard/11/definition", 
+  "href": "/api/dashboard/11", 
+  "id": 11, 
   "imported_from": null
 }

--- a/src/ts/app/manager.ts
+++ b/src/ts/app/manager.ts
@@ -163,12 +163,8 @@ const manager =
 
         events.fire(self, app.Event.DASHBOARD_LOADED, dashboard)
 
+        // Expand any templatized queries or dashboard items
         dashboard.render_templates(context.variables)
-
-        // TODO
-        // ts.charts.interactive = (context.interactive != undefined)
-        //  ? context.interactive
-        //  : ts.charts.current_provider.is_interactive
 
         // Render the dashboard
         $(element).html(dashboard.definition.render())

--- a/src/ts/charts/core.ts
+++ b/src/ts/charts/core.ts
@@ -1,4 +1,5 @@
 import Chart from '../models/items/chart'
+import DashboardItem from '../models/items/item'
 import { NamedObject, Registry } from '../core/registry'
 import * as graphite from '../data/graphite'
 
@@ -66,12 +67,12 @@ export function set_renderer(r: string|ChartRenderer) {
    Global delegates
    ============================================================================= */
 
-export function get_renderer(item: Chart|string) : ChartRenderer {
+export function get_renderer(item: DashboardItem|string) : ChartRenderer {
   let name = undefined
   if (typeof item === 'string') {
     name = item
   } else {
-    name = item.renderer
+    name = item['renderer']
   }
   return renderers.get(name) || renderer
 }

--- a/src/ts/charts/core.ts
+++ b/src/ts/charts/core.ts
@@ -66,52 +66,71 @@ export function set_renderer(r: string|ChartRenderer) {
    Global delegates
    ============================================================================= */
 
+export function get_renderer(item: Chart|string) : ChartRenderer {
+  let name = undefined
+  if (typeof item === 'string') {
+    name = item
+  } else {
+    name = item.renderer
+  }
+  return renderers.get(name) || renderer
+}
+
 export function simple_line_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.simple_line_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.simple_line_chart(element, item)
   }
 }
 
 export function standard_line_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.standard_line_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.standard_line_chart(element, item)
   }
 }
 
 export function simple_area_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.simple_area_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.simple_area_chart(element, item)
   }
 }
 
 export function stacked_area_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.stacked_area_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.stacked_area_chart(element, item)
   }
 }
 
 export function donut_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.donut_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.donut_chart(element, item)
   }
 }
 
 export function bar_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.bar_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.bar_chart(element, item)
   }
 }
 
 export function discrete_bar_chart(element: any, item: Chart) : void {
-  if (renderer) {
-    renderer.discrete_bar_chart(element, item)
+  let r = get_renderer(item)
+  if (r) {
+    r.discrete_bar_chart(element, item)
   }
 }
 
 export function process_series(series: graphite.DataSeries, type?: string) : any {
-  return renderer ? renderer.process_series(series) : series
+  let r = get_renderer(type)
+  return r ? r.process_series(series) : series
 }
 
 export function process_data(data: graphite.DataSeriesList|graphite.DataSeries, type?: string) : any {
-  return renderer ? renderer.process_data(data) : data
+  let r = get_renderer(type)
+  return r ? r.process_data(data) : data
 }

--- a/src/ts/charts/graphite.ts
+++ b/src/ts/charts/graphite.ts
@@ -173,10 +173,12 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
       .setQuery('title', options.showTitle ? item.title : '')
       .setQuery('lineMode', 'connected')
 
-    // TODO - stack_mode (restrict to type Chart)
-    // if (!item.query.is_stacked() && item.stack_mode != charts.StackMode.NONE) {
-    // png_url.setQuery('areaMode', 'stacked')
-    // }
+    if (item.hasOwnProperty('stack_mode')) {
+
+      if (!item.query.is_stacked() && item['stack_mode'] != charts.StackMode.NONE) {
+        png_url.setQuery('areaMode', 'stacked')
+      }
+    }
 
     if (options.y1 && options.y1.min) {
       png_url.setQuery('yMin', options.y1.min )

--- a/src/ts/models/items/chart.ts
+++ b/src/ts/models/items/chart.ts
@@ -3,6 +3,7 @@ import Axis from '../axis'
 import { DashboardItemMetadata } from './item'
 import { properties, PropertyList } from '../../core/property'
 import * as util from '../../core/util'
+import * as charts from '../../charts/core'
 import PALETTES from '../../charts/palettes'
 
 properties.register({
@@ -50,6 +51,7 @@ export default class Chart extends Presentation {
 
   legend: string = ChartLegendType.SIMPLE
   hide_zero_series: boolean = false
+  renderer: string
   options: any = {}
 
   constructor(data?: any) {
@@ -73,13 +75,20 @@ export default class Chart extends Presentation {
       if (typeof(data.hide_zero_series !== 'undefined')) {
         this.hide_zero_series = Boolean(data.hide_zero_series)
       }
+      this.renderer = data.renderer
     }
+  }
+
+  set_renderer(renderer: string) : Chart {
+    this.renderer = renderer
+    return this
   }
 
   toJSON() : any {
     let data = util.extend(super.toJSON(), {
       legend: this.legend,
-      hide_zero_series: this.hide_zero_series
+      hide_zero_series: this.hide_zero_series,
+      renderer: this.renderer
     })
     if (this.options) {
       data.options = util.extend({}, this.options)
@@ -104,6 +113,17 @@ export default class Chart extends Presentation {
     let props = [
       'title',
       { name: 'hide_zero_series', type: 'boolean' },
+      {
+        name: 'chart.renderer',
+        property_name: 'renderer',
+        category: 'chart',
+        edit_options: {
+          type: 'select',
+          source: function() {
+            return [undefined].concat([...charts.renderers.list().map(r => r.name)])
+          }
+        }
+      },
       {
         name: 'chart.y-axis-label',
         property_name: 'y-axis-label',

--- a/src/ts/models/items/dashboard_definition.ts
+++ b/src/ts/models/items/dashboard_definition.ts
@@ -79,7 +79,7 @@ export default class DashboardDefinition extends Container {
       if (item instanceof Presentation) {
         var query = item.query_override || item.query
         if (query) {
-          if (item.meta.requires_data || charts.renderer.is_interactive) {
+          if (item.meta.requires_data || charts.get_renderer(item).is_interactive) {
             queries_to_load[query.name] = query
             delete queries_to_fire[query.name]
           } else {

--- a/src/ts/models/items/item.ts
+++ b/src/ts/models/items/item.ts
@@ -60,7 +60,6 @@ export default class DashboardItem extends Model {
   height: number
   style: string
   title: string
-  interactive: boolean // TODO - this can probably go away
   dashboard: any // TODO - Dashboard type when ready
   options: any
 
@@ -133,11 +132,6 @@ export default class DashboardItem extends Model {
 
   set_css_class(value: string) : DashboardItem {
     this.css_class = value
-    return this
-  }
-
-  set_interactive(value: boolean) : DashboardItem {
-    this.interactive = value
     return this
   }
 

--- a/src/ts/models/transform/Isolate.ts
+++ b/src/ts/models/transform/Isolate.ts
@@ -1,5 +1,6 @@
 import { transforms } from './transform'
 import { make } from '../items/factory'
+import Chart from '../items/chart'
 
 /**
  * Focus on a single presentation.
@@ -11,13 +12,15 @@ transforms.register({
 
   transform: function(item: any) : any {
     var options = item.options || {}
+    if (item instanceof Chart) {
+        item.set_renderer('flot')
+    }
     return make('section')
       .add(make('row')
            .add(make('cell')
                 .set_span(12)
                 .set_style('well')
-                .add(item.set_height(6)
-                     .set_interactive(true))))
+                .add(item.set_height(6))))
       .add(make('row')
            .add(make('cell')
                 .set_span(12)


### PR DESCRIPTION
Restores the behavior of having an interactive view in ‘Isolate’, while
also allowing more flexibility in display on dashboards. Now if there’s
something you need to do with a graphite query that flot charts don’t
support, you can selectively use graphite’s PNG renderer.

Fixes #418 