### PR TITLE
drop simplejson requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ flask-sqlalchemy==1.0
 flask-migrate==1.2
 sqlalchemy==0.9.4
 requests==2.3.0
-simplejson==3.5.2
 inflection==0.2.0
 tessera-client==0.4.3


### PR DESCRIPTION
it isn't imported directly and shipped with python >= 2.6