### PR TITLE
fix bootstrap-growl broken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bluebird": "^2.9.25",
     "bootbox": "^4.4.0",
     "bootstrap": "^3.3.4",
-    "bootstrap-growl": "^2.0.0",
+    "bootstrap-growl": "^3.1.3",
     "bootstrap-solarized": "^1.0.2",
     "color": "^0.8.0",
     "d3": "^3.5.5",


### PR DESCRIPTION
When i try npm install
i got following errors

<pre>
npm ERR! Linux 3.13.0-55-generic
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v2.11.3
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: bootstrap-growl@'>=2.0.0 <3.0.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["3.1.3"]
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'tessera'
npm ERR! notarget
</pre>