### PR TITLE
Sparktable

### DIFF
--- a/tessera-frontend/src/css/tessera.css
+++ b/tessera-frontend/src/css/tessera.css
@@ -400,6 +400,21 @@ td.ds-diff-minus {
     margin-bottom: 0px;
 }
 
+.ds-spark-table-graph {
+  width: 100%;
+  height: 1.5em;
+}
+
+.ds-summation-table td,
+.ds-summation-table th {
+  vertical-align: middle !important;
+}
+
+.ds-summation-table tbody th {
+  font-weight: normal;
+}
+
+
 /* -----------------------------------------------------------------------------
  Edit mode headers
  ----------------------------------------------------------------------------- */

--- a/tessera-frontend/src/css/tessera.css
+++ b/tessera-frontend/src/css/tessera.css
@@ -400,6 +400,10 @@ td.ds-diff-minus {
     margin-bottom: 0px;
 }
 
+col.ds-sparkline-col {
+  width:100%;
+}
+
 .ds-spark-table-graph {
   width: 100%;
   height: 1.5em;

--- a/tessera-frontend/src/templates/models/summation_table.hbs
+++ b/tessera-frontend/src/templates/models/summation_table.hbs
@@ -10,7 +10,7 @@
       {{#if item.show_mean}}<col>{{/if}}
       {{#if item.show_median}}<col>{{/if}}
       {{#if item.show_sum}}<col>{{/if}}
-      {{#if item.show_sparkline}}<col style="width:20%">{{/if}}
+      {{#if item.show_sparkline}}<col class="ds-sparkline-col">{{/if}}
     </colgroup>
     <thead>
       <tr>

--- a/tessera-frontend/src/templates/models/summation_table.hbs
+++ b/tessera-frontend/src/templates/models/summation_table.hbs
@@ -2,15 +2,26 @@
   {{> ds-title-bar}}
   <table class="table table-condensed ds-summation-table {{height item}} {{css_class item}}
                 {{#if item.striped}}table-striped{{/if}}">
+    <colgroup>
+      <col>
+      {{#if item.show_current}}<col>{{/if}}
+      {{#if item.show_min}}<col>{{/if}}
+      {{#if item.show_max}}<col>{{/if}}
+      {{#if item.show_mean}}<col>{{/if}}
+      {{#if item.show_median}}<col>{{/if}}
+      {{#if item.show_sum}}<col>{{/if}}
+      {{#if item.show_sparkline}}<col style="width:20%">{{/if}}
+    </colgroup>
     <thead>
       <tr>
         <th>&nbsp;</th>
-        <th>current</th>
-        <th>min</th>
-        <th>max</th>
-        <th>mean</th>
-        <th>median</th>
-        <th>sum</th>
+        {{#if item.show_current}}<th>current</th>{{/if}}
+        {{#if item.show_min}}<th>min</th>{{/if}}
+        {{#if item.show_max}}<th>max</th>{{/if}}
+        {{#if item.show_mean}}<th>mean</th>{{/if}}
+        {{#if item.show_median}}<th>median</th>{{/if}}
+        {{#if item.show_sum}}<th>sum</th>{{/if}}
+        {{#if item.show_sparkline}}<th>&nbsp;</th>{{/if}}
       </tr>
     </thead>
     <tbody>

--- a/tessera-frontend/src/templates/models/summation_table_row.hbs
+++ b/tessera-frontend/src/templates/models/summation_table_row.hbs
@@ -1,13 +1,19 @@
 <tr>
-    <th>
+  <th>
     {{#if item.show_color}}
       <span class="ds-summation-color-cell" style="background:{{color}}"></span>
     {{/if}}
-      {{series.target}}</th>
-    <td>{{format item.format series.summation.last}}</td>
-    <td>{{format item.format series.summation.min}}</td>
-    <td>{{format item.format series.summation.max}}</td>
-    <td>{{format item.format series.summation.mean}}</td>
-    <td>{{format item.format series.summation.median}}</td>
-    <td>{{format item.format series.summation.sum}}</td>
-  </tr>
+    {{series.target}}
+  </th>
+  {{#if item.show_current}}<td>{{format item.format series.summation.last}}</td>{{/if}}
+  {{#if item.show_min}}<td>{{format item.format series.summation.min}}</td>{{/if}}
+  {{#if item.show_max}}<td>{{format item.format series.summation.max}}</td>{{/if}}
+  {{#if item.show_mean}}<td>{{format item.format series.summation.mean}}</td>{{/if}}
+  {{#if item.show_median}}<td>{{format item.format series.summation.median}}</td>{{/if}}
+  {{#if item.show_sum}}<td>{{format item.format series.summation.sum}}</td>{{/if}}
+  {{#if item.show_sparkline}}
+    <td>
+      <div class="ds-spark-table-graph" id="{{item.item_id}}-sparkline-{{index}}"></div>
+    </td>
+  {{/if}}
+</tr>

--- a/tessera-frontend/src/ts/charts/flot.ts
+++ b/tessera-frontend/src/ts/charts/flot.ts
@@ -272,6 +272,30 @@ export default class FlotChartRenderer extends charts.ChartRenderer {
     }
   }
 
+  sparkline(e: any, query: Query, index: number, opt?: any) {
+    let data = [query.chart_data('flot')[index]]
+    let options = extend(true, {}, {
+      colors: get_palette(),
+      series: {
+        lines: {
+          show: true,
+          lineWidth: 1,
+          fill: 0.4
+        }
+      },
+      grid: { show: false },
+      legend: { show: false },
+      shadowSize: 0,
+      downsample: true
+    }, opt)
+    return {
+      plot: $.plot(e, data, options),
+      query: query,
+      index: index,
+      renderer: this
+    }
+  }
+
   render(e: any, item: Chart, query: Query, options?: any, data?: any) : any {
     if (typeof(data) === 'undefined')
       data = query.chart_data('flot')

--- a/tessera-frontend/src/ts/models/items/summation_table.ts
+++ b/tessera-frontend/src/ts/models/items/summation_table.ts
@@ -63,7 +63,7 @@ export default class SummationTable extends TablePresentation {
     log.debug(`data_handler(): ${query.name}/${this.item_id}`)
     let options = this.options || {}
     let palette = charts.get_palette(options.palette || this.palette)
-    let body = $('#' + this.item_id + ' tbody')
+    let body = $('#' + this.item_id + ' table.ds-summation-table tbody')
     let flot = <charts.FlotChartRenderer>charts.renderers.get('flot')
     body.empty()
     query.data.forEach((series, i) => {
@@ -71,7 +71,11 @@ export default class SummationTable extends TablePresentation {
       body.append(ts.templates.models.summation_table_row({series:series, item:this, color: color, index: i}))
       if (this.show_sparkline) {
         let plot_div = $(`#${this.item_id}-sparkline-${i}`)
-        flot.sparkline(plot_div, query, i)
+        let options : any = {}
+        if (this.show_color) {
+          options.colors = [color]
+        }
+        flot.sparkline(plot_div, query, i, options)
       }
     })
     if (this.sortable) {

--- a/tessera-frontend/src/ts/models/items/summation_table.ts
+++ b/tessera-frontend/src/ts/models/items/summation_table.ts
@@ -71,9 +71,10 @@ export default class SummationTable extends TablePresentation {
       body.append(ts.templates.models.summation_table_row({series:series, item:this, color: color, index: i}))
       if (this.show_sparkline) {
         let plot_div = $(`#${this.item_id}-sparkline-${i}`)
-        let options : any = {}
-        if (this.show_color) {
-          options.colors = [color]
+        let options = {
+          colors: this.show_color
+            ? [color]
+            : palette
         }
         flot.sparkline(plot_div, query, i, options)
       }

--- a/tessera-frontend/src/ts/models/items/summation_table.ts
+++ b/tessera-frontend/src/ts/models/items/summation_table.ts
@@ -1,7 +1,7 @@
 import TablePresentation from './table_presentation'
 import * as core from '../../core'
 import Query from '../data/query'
-import * as charts from '../../charts/util'
+import * as charts from '../../charts'
 
 declare var $, ts
 
@@ -9,9 +9,17 @@ const log = core.logger('models.summation_table')
 
 export default class SummationTable extends TablePresentation {
 
-  show_color: boolean = false
   options: any
   palette: string
+
+  show_color: boolean = false
+  show_min : boolean = true
+  show_max : boolean = true
+  show_mean : boolean = true
+  show_median : boolean = true
+  show_sum : boolean = true
+  show_current : boolean = true
+  show_sparkline : boolean = false
 
   constructor(data?: any) {
     super(data)
@@ -19,12 +27,33 @@ export default class SummationTable extends TablePresentation {
       this.show_color = !!data.show_color
       this.options = data.options
       this.palette = data.palette
+      if (typeof data.show_min != 'undefined')
+        this.show_min = !!data.show_min
+      if (typeof data.show_max != 'undefined')
+        this.show_max = !!data.show_max
+      if (typeof data.show_mean != 'undefined')
+        this.show_mean = !!data.show_mean
+      if (typeof data.show_median != 'undefined')
+        this.show_median = !!data.show_median
+      if (typeof data.show_sum != 'undefined')
+        this.show_sum = !!data.show_sum
+      if (typeof data.show_current != 'undefined')
+        this.show_current = !!data.show_current
+      if (typeof data.show_sparkline != 'undefined')
+        this.show_sparkline = !!data.show_sparkline
     }
   }
 
   toJSON() : any {
     return core.extend(super.toJSON(), {
       show_color: this.show_color,
+      show_min: this.show_min,
+      show_max: this.show_max,
+      show_mean: this.show_mean,
+      show_median: this.show_median,
+      show_sum: this.show_sum,
+      show_current: this.show_current,
+      show_sparkline: this.show_sparkline,
       options: this.options,
       palette: this.palette
     })
@@ -35,10 +64,15 @@ export default class SummationTable extends TablePresentation {
     let options = this.options || {}
     let palette = charts.get_palette(options.palette || this.palette)
     let body = $('#' + this.item_id + ' tbody')
+    let flot = <charts.FlotChartRenderer>charts.renderers.get('flot')
     body.empty()
     query.data.forEach((series, i) => {
       let color = palette[i % palette.length]
-      body.append(ts.templates.models.summation_table_row({series:series, item:this, color: color}))
+      body.append(ts.templates.models.summation_table_row({series:series, item:this, color: color, index: i}))
+      if (this.show_sparkline) {
+        let plot_div = $(`#${this.item_id}-sparkline-${i}`)
+        flot.sparkline(plot_div, query, i)
+      }
     })
     if (this.sortable) {
         body.parent().DataTable({
@@ -52,8 +86,16 @@ export default class SummationTable extends TablePresentation {
 
   interactive_properties() : core.PropertyList {
     return super.interactive_properties().concat([
-      { name: 'show_color', type: 'boolean' },
-      'chart.palette'
+      { name: 'show_color', type: 'boolean', category: 'summation' },
+      { name: 'show_min', type: 'boolean', category: 'summation' },
+      { name: 'show_max', type: 'boolean', category: 'summation' },
+      { name: 'show_mean', type: 'boolean', category: 'summation' },
+      { name: 'show_median', type: 'boolean', category: 'summation' },
+      { name: 'show_sum', type: 'boolean', category: 'summation' },
+      { name: 'show_current', type: 'boolean', category: 'summation' },
+      { name: 'show_sparkline', type: 'boolean', category: 'summation' },
+      'chart.palette',
+      'title'
     ])
   }
 }


### PR DESCRIPTION
This is a bunch of updates to `summation_table` that add two major features:
* Allows the selection of which columns are displayed
* Adds the option of a sparkline

I thought there was a long-standing issue for this, but turns out it was just an item in the TODO wiki page. 