### PR TITLE
Issue 319 view the query

### DIFF
--- a/tessera-frontend/src/templates/action.hbs
+++ b/tessera-frontend/src/templates/action.hbs
@@ -7,6 +7,6 @@
     data-ds-category="{{category}}"
     data-ds-show="{{action.show}}"
     data-ds-hide="{{action.hide}}">
-    <a role="menuitem" href="#"><i class="fa-fw {{action.icon}}"></i> {{action.display}}</a>
+    <a role="menuitem" href="#"><i class="fa fa-fw {{action.icon}}"></i> {{action.display}}</a>
   </li>
 {{/if}}

--- a/tessera-frontend/src/templates/edit/view_query.hbs
+++ b/tessera-frontend/src/templates/edit/view_query.hbs
@@ -1,0 +1,3 @@
+<div class="ds-query-source">
+  {{markdown source}}
+</div>

--- a/tessera-frontend/src/ts/app/handlers/menu-presentation-actions.ts
+++ b/tessera-frontend/src/ts/app/handlers/menu-presentation-actions.ts
@@ -1,12 +1,29 @@
+declare var ts, bootbox
 import manager from '../manager'
 import Action, { actions } from '../../core/action'
 import * as graphite from '../../charts/graphite'
 
 actions.register('presentation-actions', [
   new Action({
+    name: 'view-query',
+    display: 'View query...',
+    icon: 'fa-question',
+    handler: (action, item) => {
+      let query = item.query_override || item.query
+      let expr  = query.targets[0]
+      let source = `### Query: ${item.query.name}
+
+\`\`\`
+${expr}
+\`\`\`
+`
+      bootbox.alert(ts.templates.edit.view_query({ source: source }))
+    }
+  }),
+  new Action({
     name:    'open-in-graphite',
     display: 'Open in Graphite...',
-    icon:    'fa fa-bar-chart-o',
+    icon:    'fa-bar-chart-o',
     handler: function(action, item) {
       let composer_url = graphite.composer_url(item, item.query_override || item.query, {
         showTitle: true
@@ -17,7 +34,7 @@ actions.register('presentation-actions', [
   new Action({
     name:    'export-png',
     display: 'Export PNG...',
-    icon:    'fa fa-file-image-o',
+    icon:    'fa-file-image-o',
     handler: function(action, item) {
       let image_url = graphite.chart_url(item, item.query_override || item.query, {
         showTitle: true
@@ -28,7 +45,7 @@ actions.register('presentation-actions', [
   new Action({
     name:    'export-svg',
     display: 'Export SVG...',
-    icon:    'fa fa-file-code-o',
+    icon:    'fa-file-code-o',
     handler: function(action, item) {
       let image_url = graphite.chart_url(item, item.query_override || item.query, {
         showTitle: true,
@@ -40,7 +57,7 @@ actions.register('presentation-actions', [
   new Action({
     name:    'export-csv',
     display: 'Export CSV...',
-    icon:    'fa fa-file-excel-o',
+    icon:    'fa-file-excel-o',
     handler: function(action, item) {
       let image_url = graphite.chart_url(item, item.query_override || item.query, {
         showTitle: true,

--- a/tessera-frontend/src/ts/models/items/markdown.ts
+++ b/tessera-frontend/src/ts/models/items/markdown.ts
@@ -23,6 +23,11 @@ export default class Markdown extends DashboardItem {
     }
   }
 
+  set_text(value: string) : Markdown {
+    this.text = value
+    return <Markdown> this.updated()
+  }
+
   render_templates(context?: any) : void {
     try {
       this.expanded_text = render_template(this.text, context)

--- a/tessera-frontend/src/ts/models/transform/Isolate.ts
+++ b/tessera-frontend/src/ts/models/transform/Isolate.ts
@@ -1,4 +1,4 @@
-import { transforms } from './transform'
+import { transforms, render_query } from './transform'
 import { make } from '../items/factory'
 import Chart from '../items/chart'
 
@@ -11,16 +11,21 @@ transforms.register({
   transform_type: 'presentation',
 
   transform: function(item: any) : any {
-    var options = item.options || {}
+    let options = item.options || {}
     if (item instanceof Chart) {
         item.set_renderer('flot')
     }
+
     return make('section')
       .add(make('row')
            .add(make('cell')
                 .set_span(12)
                 .set_style('well')
                 .add(item.set_height(6))))
+      .add(make('row')
+           .add(make('cell')
+                .set_span(12)
+                .add(render_query(item.query))))
       .add(make('row')
            .add(make('cell')
                 .set_span(12)

--- a/tessera-frontend/src/ts/models/transform/transform.ts
+++ b/tessera-frontend/src/ts/models/transform/transform.ts
@@ -2,6 +2,9 @@ import { NamedObject, Registry } from '../../core/registry'
 import Action, { actions } from '../../core/action'
 import manager from '../../app/manager'
 import * as app from '../../app/app'
+import Query from '../data/query'
+import Markdown from '../items/markdown'
+import { make } from '../items/factory'
 
 export const TransformType = {
   DASHBOARD: 'dashboard',
@@ -61,3 +64,15 @@ export const transforms = new Registry<Transform>({
     return transform
   }
 })
+
+export function render_query(query: Query) : Markdown {
+    let markdown = `
+#### Query: ${query.name}
+
+\`\`\`
+${query.targets[0]}
+\`\`\`
+`
+  return make('markdown')
+    .set_text(markdown)
+}


### PR DESCRIPTION
Implements issue #319  - quick access to viewing the definition of the query for a specific dashboard item without going into edit mode. Also adds a view of the query to the Isolate transform.