### PR TITLE
More memory leak tweaking

### DIFF
--- a/tessera-frontend/src/ts/app/manager.ts
+++ b/tessera-frontend/src/ts/app/manager.ts
@@ -170,7 +170,7 @@ export class Manager {
     log.debug('load(): ' + url)
 
     if (this.current && this.current.dashboard) {
-      this.current.dashboard.cleanup()
+      this.current.dashboard.visit(item => item.cleanup())
     }
     let holder = new DashboardHolder(url, element)
     let context = this._prep_url(url, options)

--- a/tessera-frontend/src/ts/charts.ts
+++ b/tessera-frontend/src/ts/charts.ts
@@ -6,7 +6,8 @@ export {
   ChartRenderer, get_renderer, set_renderer, renderers,
   StackMode,
   simple_line_chart, standard_line_chart, simple_area_chart, stacked_area_chart,
-  donut_chart, bar_chart, discrete_bar_chart, process_series, process_data
+  donut_chart, bar_chart, discrete_bar_chart, process_series, process_data,
+  cleanup
 } from './charts/core'
 
 export {

--- a/tessera-frontend/src/ts/charts/core.ts
+++ b/tessera-frontend/src/ts/charts/core.ts
@@ -28,15 +28,16 @@ export class ChartRenderer implements NamedObject {
     }
   }
 
-  simple_line_chart(element: any, item: Chart, query: Query) : void {}
-  standard_line_chart(element: any, item: Chart, query: Query) : void {}
-  simple_area_chart(element: any, item: Chart, query: Query) : void {}
-  stacked_area_chart(element: any, item: Chart, query: Query) : void {}
-  donut_chart(element: any, item: Chart, query: Query) : void {}
-  bar_chart(element: any, item: Chart, query: Query) : void {}
-  discrete_bar_chart(element: any, item: Chart, query: Query) : void {}
+  simple_line_chart(selector: string, item: Chart, query: Query) : void {}
+  standard_line_chart(selector: string, item: Chart, query: Query) : void {}
+  simple_area_chart(selector: string, item: Chart, query: Query) : void {}
+  stacked_area_chart(selector: string, item: Chart, query: Query) : void {}
+  donut_chart(selector: string, item: Chart, query: Query) : void {}
+  bar_chart(selector: string, item: Chart, query: Query) : void {}
+  discrete_bar_chart(selector: string, item: Chart, query: Query) : void {}
   highlight_series(item: Chart, index: number) : void {}
   unhighlight_series(item: Chart, index?: number) : void {}
+  cleanup(item: Chart) : void {}
 
   process_series(series: graphite.DataSeries) : any {
     return series
@@ -96,52 +97,52 @@ export function get_renderer(item?: DashboardItem|string) : ChartRenderer {
   return renderers.get(name) || renderer
 }
 
-export function simple_line_chart(element: any, item: Chart, query: Query) : void {
+export function simple_line_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.simple_line_chart(element, item, query)
+    r.simple_line_chart(selector, item, query)
   }
 }
 
-export function standard_line_chart(element: any, item: Chart, query: Query) : void {
+export function standard_line_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.standard_line_chart(element, item, query)
+    r.standard_line_chart(selector, item, query)
   }
 }
 
-export function simple_area_chart(element: any, item: Chart, query: Query) : void {
+export function simple_area_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.simple_area_chart(element, item, query)
+    r.simple_area_chart(selector, item, query)
   }
 }
 
-export function stacked_area_chart(element: any, item: Chart, query: Query) : void {
+export function stacked_area_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.stacked_area_chart(element, item, query)
+    r.stacked_area_chart(selector, item, query)
   }
 }
 
-export function donut_chart(element: any, item: Chart, query: Query) : void {
+export function donut_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.donut_chart(element, item, query)
+    r.donut_chart(selector, item, query)
   }
 }
 
-export function bar_chart(element: any, item: Chart, query: Query) : void {
+export function bar_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.bar_chart(element, item, query)
+    r.bar_chart(selector, item, query)
   }
 }
 
-export function discrete_bar_chart(element: any, item: Chart, query: Query) : void {
+export function discrete_bar_chart(selector: string, item: Chart, query: Query) : void {
   let r = get_renderer(item)
   if (r) {
-    r.discrete_bar_chart(element, item, query)
+    r.discrete_bar_chart(selector, item, query)
   }
 }
 
@@ -153,4 +154,11 @@ export function process_series(series: graphite.DataSeries, type?: string) : any
 export function process_data(data: graphite.DataSeriesList|graphite.DataSeries, type?: string) : any {
   let r = get_renderer(type)
   return r ? r.process_data(data) : data
+}
+
+export function cleanup(item: Chart) : void {
+  let r = get_renderer(item)
+  if (r) {
+    r.cleanup(item)
+  }
 }

--- a/tessera-frontend/src/ts/charts/graphite.ts
+++ b/tessera-frontend/src/ts/charts/graphite.ts
@@ -52,7 +52,8 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     }
   }
 
-  simple_line_chart(element: any, item: Chart, query: Query) : void {
+  simple_line_chart(selector: string, item: Chart, query: Query) : void {
+    let element = $(selector)
     let url = this.simple_line_chart_url(item, query, {
       height: element.height(),
       width: element.width()
@@ -89,7 +90,8 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     return png_url
   }
 
-  standard_line_chart(element: any, item: Chart, query: Query) : void {
+  standard_line_chart(selector: string, item: Chart, query: Query) : void {
+    let element = $(selector)
     let url = this.standard_line_chart_url(item, query, {
       height: element.height(),
       width: element.width()
@@ -126,7 +128,8 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     return png_url
   }
 
-  simple_area_chart(element: any, item: Chart, query: Query) : void {
+  simple_area_chart(selector: string, item: Chart, query: Query) : void {
+    let element = $(selector)
     let url = this.simple_area_chart_url(item, query, {
       height: element.height(),
       width: element.width()
@@ -165,7 +168,8 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     return png_url
   }
 
-  stacked_area_chart(element: any, item: Chart, query: Query) : void {
+  stacked_area_chart(selector: string, item: Chart, query: Query) : void {
+    let element = $(selector)
     let url = this.stacked_area_chart_url(item, query, {
       height: element.height(),
       width: element.width()
@@ -215,7 +219,8 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     return png_url
   }
 
-  donut_chart(element: any, item: Chart, query: Query) : void {
+  donut_chart(selector: string, item: Chart, query: Query) : void {
+    let element = $(selector)
     let url = this.donut_chart_url(item, query, {
       height: element.height(),
       width: element.width()
@@ -224,12 +229,12 @@ export default class GraphiteChartRenderer extends charts.ChartRenderer {
     render_legend(item, query)
   }
 
-  bar_chart(element: any, item: Chart, query: Query) : void{
-    this.stacked_area_chart(element, item, query)
+  bar_chart(selector: string, item: Chart, query: Query) : void{
+    this.stacked_area_chart(selector, item, query)
   }
 
-  discrete_bar_chart(element: any, item: Chart, query: Query) : void {
-    this.donut_chart(element, item, query)
+  discrete_bar_chart(selector: string, item: Chart, query: Query) : void {
+    this.donut_chart(selector, item, query)
   }
 
   chart_url(item: Chart, query: Query, opt?: any) {

--- a/tessera-frontend/src/ts/models/data/query.ts
+++ b/tessera-frontend/src/ts/models/data/query.ts
@@ -175,6 +175,12 @@ export default class Query extends Model {
     core.events.off(this, 'ds-data-ready')
   }
 
+  cleanup() : void {
+    this.off()
+    this.cache.clear()
+    this.data = null
+  }
+
   _group_targets() : string {
     return (this.targets.length > 1)
       ? 'group(' + this.targets.join(',') + ')'

--- a/tessera-frontend/src/ts/models/items/bar_chart.ts
+++ b/tessera-frontend/src/ts/models/items/bar_chart.ts
@@ -28,7 +28,7 @@ export default class BarChart extends XYChart {
   }
 
   data_handler(query: Query) : void {
-    charts.bar_chart($('#' + this.item_id + ' .ds-graph-holder'), this, query)
+    charts.bar_chart('#' + this.item_id + ' .ds-graph-holder', this, query)
   }
 
   interactive_properties() : PropertyList {

--- a/tessera-frontend/src/ts/models/items/chart.ts
+++ b/tessera-frontend/src/ts/models/items/chart.ts
@@ -91,7 +91,7 @@ export default class Chart extends Presentation {
   }
 
   cleanup() : void {
-    this.render_context = null
+    charts.cleanup(this)
   }
 
   set_renderer(renderer: string) : Chart {

--- a/tessera-frontend/src/ts/models/items/dashboard_definition.ts
+++ b/tessera-frontend/src/ts/models/items/dashboard_definition.ts
@@ -60,13 +60,8 @@ export default class DashboardDefinition extends Container {
 
   cleanup() {
     for (let key in this.queries) {
-      this.queries[key].off()
+      this.queries[key].cleanup()
     }
-    this.visit(item => {
-      if (!(<any>item instanceof DashboardDefinition)) {
-        item.cleanup()
-      }
-    })
   }
 
   list_queries() {

--- a/tessera-frontend/src/ts/models/items/discrete_bar_chart.ts
+++ b/tessera-frontend/src/ts/models/items/discrete_bar_chart.ts
@@ -46,7 +46,7 @@ export default class DiscreteBarChart extends Chart {
   }
 
   data_handler(query: Query) : void {
-    charts.discrete_bar_chart($('#' + this.item_id + ' .ds-graph-holder'), this, query)
+    charts.discrete_bar_chart('#' + this.item_id + ' .ds-graph-holder', this, query)
   }
 
   interactive_properties() : PropertyList {

--- a/tessera-frontend/src/ts/models/items/donut_chart.ts
+++ b/tessera-frontend/src/ts/models/items/donut_chart.ts
@@ -35,7 +35,7 @@ export default class DonutChart extends Chart {
   }
 
   data_handler(query: Query) : void {
-    charts.donut_chart($("#" + this.item_id + ' .ds-graph-holder'), this, query)
+    charts.donut_chart("#" + this.item_id + ' .ds-graph-holder', this, query)
   }
 
   interactive_properties(): PropertyList {

--- a/tessera-frontend/src/ts/models/items/simple_time_series.ts
+++ b/tessera-frontend/src/ts/models/items/simple_time_series.ts
@@ -43,9 +43,9 @@ export default class SimpleTimeSeries extends XYChart {
   data_handler(query: Query) : void {
     let selector = `#${this.item_id} .ds-graph-holder`
     if (this.filled) {
-      charts.simple_area_chart($(selector), this, query)
+      charts.simple_area_chart(selector, this, query)
     } else {
-      charts.simple_line_chart($(selector), this, query)
+      charts.simple_line_chart(selector, this, query)
     }
   }
 

--- a/tessera-frontend/src/ts/models/items/singlegraph.ts
+++ b/tessera-frontend/src/ts/models/items/singlegraph.ts
@@ -44,7 +44,7 @@ export default class Singlegraph extends Chart {
     let options = {
       colors: charts.get_palette(this.options.palette)
     }
-    flot.sparkline($(`#${this.item_id} .ds-graph-holder`), this, query, 0, options)
+    flot.sparkline(`#${this.item_id} .ds-graph-holder`, this, query, 0, options)
     this.options.margin = { top: 0, left: 0, bottom: 0, right: 0 }
     var label = query.data[this.index || 0].target
     var value = query.summation[this.transform]

--- a/tessera-frontend/src/ts/models/items/singlegraph_grid.ts
+++ b/tessera-frontend/src/ts/models/items/singlegraph_grid.ts
@@ -57,7 +57,7 @@ export default class SinglegraphGrid extends Chart {
         value: format(value),
         label: series.target
       }))
-      flot.sparkline($(`#${this.item_id}-${i} .ds-graph-holder`), this, query, i, options)
+      flot.sparkline(`#${this.item_id}-${i} .ds-graph-holder`, this, query, i, options)
     })
   }
 

--- a/tessera-frontend/src/ts/models/items/stacked_area_chart.ts
+++ b/tessera-frontend/src/ts/models/items/stacked_area_chart.ts
@@ -67,7 +67,7 @@ export default class StackedAreaChart extends XYChart {
   }
 
   data_handler(query: Query) : void {
-    charts.stacked_area_chart($(`#${this.item_id} .ds-graph-holder`), this, query)
+    charts.stacked_area_chart(`#${this.item_id} .ds-graph-holder`, this, query)
   }
 
   interactive_properties() : PropertyList {

--- a/tessera-frontend/src/ts/models/items/standard_time_series.ts
+++ b/tessera-frontend/src/ts/models/items/standard_time_series.ts
@@ -15,6 +15,6 @@ export default class StandardTimeSeries extends XYChart {
   }
 
   data_handler(query: Query) : void {
-    charts.standard_line_chart($(`#${this.item_id} .ds-graph-holder`), this, query)
+    charts.standard_line_chart(`#${this.item_id} .ds-graph-holder`, this, query)
   }
 }

--- a/tessera-frontend/src/ts/models/items/table_presentation.ts
+++ b/tessera-frontend/src/ts/models/items/table_presentation.ts
@@ -31,6 +31,14 @@ export default class TablePresentation extends Presentation {
     })
   }
 
+  cleanup() : void {
+    let table = $('#' + this.item_id + ' table')
+    if ($.fn.dataTable.isDataTable(table)) {
+      console.log('table_presentation(): destroying datatable')
+      table.DataTable().destroy()
+    }
+  }
+
   interactive_properties() : PropertyList {
     return super.interactive_properties().concat([
       { name: 'striped', type: 'boolean' },


### PR DESCRIPTION
Second round of cleanups for #528 

- Delay obtaining DOM nodes as long as possible in chart rendering
- Cleaner cleanup() process
- Clean up chart rendering context and cached processed data

